### PR TITLE
Add spacing between syntax structure to give titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-#Door Sensor Project
+# Door Sensor Project
 **Authors: Benjamin Anderson and Caelin Finn McCool**
 
-###PROBLEM:
+### PROBLEM:
 Students who are working in PPHAC 114(the Computer Science Lab/Lounge) do not know if the Computer Science professors are in their offices unless they walk over and see if the office doors are open.
 
-###OBJECTIVE:
+### OBJECTIVE:
 Make a program that utilizes sensors to detect if a certain office door is open or closed. If a professor is available(their office door is open), a signal in PPHAC 114 will represent that the certain professor is in their office using a constantly updating graphical display. If their door is closed, a different signal will be given for that certain professor showing that they are not in their office at that time.
 
-##Notes:
+## Notes:
 ### Disabling The Screensaver For Client Side Monitor
 
 * Type `sudo apt install xscreensaver` in the Raspberry Pi command line.


### PR DESCRIPTION
Added missing spaces between '#' symbols and titles to give the titles the Markdown structure.