### PR TITLE
Remove built in tools from requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 Flask
-logging
 pytest
 request
 requests
-tkinter


### PR DESCRIPTION
After attempting to install the requirements file, we noticed that logging and tkinter were throwing errors. Found that these two libraries are built into Python already.